### PR TITLE
Drop node to 20 in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v4
       with:
-        node-version: '21.x'
+        node-version: '20'
     - name: install deps
       run: |
         # install app deps


### PR DESCRIPTION
Applying https://github.com/openai/main-branch-check-action/commit/db55d6c822cf04fbbf086420d8af7b76173c86e0#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19 here too, reference https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax

Alternatively, they just added support for 22 https://github.com/actions/node-versions/releases/tag/22.0.0-8879734543